### PR TITLE
[BIOMAGE-2350] - Use endpoint lambda in inframock

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -57,7 +57,7 @@ def provision_biomage_stack():
     logger.info(
         "Expect harmless error on localstack.services.sns.sns_listener if the API is not running"
     )
-    resources = ("sns", "s3-v2")
+    resources = ("sns", "s3-v2", "sns-endpoint-lambda")
     for resource in resources:
         path = f"https://raw.githubusercontent.com/biomage-org/iac/master/cf/{resource}.yaml"
 


### PR DESCRIPTION
Use sns-endpoint-lambda in Inframock 

https://biomage.atlassian.net/browse/BIOMAGE-2350

**Testing in local:** 

Lambda created successfully:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/2862362/217271962-161a883e-3c44-47b3-965a-70b0b8359017.png">

Lambda passes SNS updates correctly:
https://user-images.githubusercontent.com/2862362/217272887-4fa18b25-c000-493c-a8bc-f707e1bde41c.mov

