### PR TITLE
Fix makefile commands to run sql migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ build: ## Builds the docker-compose environment
 run: build ## Builds & runs the docker environment
 	@docker-compose $(docker_files) up --force-recreate
 migrate:
-	@NODE_ENV=development AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:latest --cwd ../iac/migrations/sql-migrations/
+	@NODE_ENV=development SANDBOX_ID=default AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:latest --cwd ../iac/migrations/sql-migrations/
 migrate-down:
-	@NODE_ENV=development AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:rollback --all --cwd ../iac/migrations/sql-migrations/
+	@NODE_ENV=development SANDBOX_ID=default AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:rollback --all --cwd ../iac/migrations/sql-migrations/
 cleanup-sql:
 	rm -rf pg_data
 reload-data: migrate ## Reloads the input data found in ./data. NOTE: it will not remove from s3 generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.


### PR DESCRIPTION
Local environment migrations were broken in [this PR](https://github.com/biomage-org/iac/pull/135/files#diff-7522b110d7bb4b13dbb47bee34537d7ec0da65dd453e0a750292499a1da2c29e:~:text=directory%3A%20%27../../../api/src/sql/migrations%27).

To fix the issue on iac, we need to pull the migrations files from the local api just as before (because there is no folder "migrations/development" in iac)

To fix the issue on inframock, we need to add a couple environemnt varialbes that were added tor equirements but not provided in the ifnramock makefile commands, so they break